### PR TITLE
Remove global Ember import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/test/expected-output/remove-ember-import.js
+++ b/test/expected-output/remove-ember-import.js
@@ -1,0 +1,4 @@
+import Component from "@ember/component";
+
+export default Component.extend({
+});

--- a/test/input/remove-ember-import.js
+++ b/test/input/remove-ember-import.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+});

--- a/transform.js
+++ b/transform.js
@@ -50,6 +50,15 @@ function transform(file, api, options) {
     // imported binding (`whatever`).
     applyReplacements(replacements);
 
+    // Finally remove global Ember import
+    const globalEmber = root.find(j.ImportDeclaration, {
+      source: {
+        value: 'ember',
+      },
+    });
+
+    globalEmber.remove();
+
     // jscodeshift is not so great about giving us control over the resulting whitespace.
     // We'll use a regular expression to try to improve the situation (courtesy of @rwjblue).
     source = beautifyImports(root.toSource());


### PR DESCRIPTION
If the goal of the code mod is to remove global Ember makes sense to remove it as an import?