### PR TITLE
Don't create import of existing declaration

### DIFF
--- a/test/expected-output/existing-alias.js
+++ b/test/expected-output/existing-alias.js
@@ -1,0 +1,9 @@
+import EmberObject from "@ember/object";
+import EmberHelper from "@ember/component/helper";
+import Ember from 'ember';
+
+const Helper = EmberHelper || EmberObject;
+
+export default Helper.extend({
+
+});

--- a/test/input/existing-alias.js
+++ b/test/input/existing-alias.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+const Helper = Ember.Helper || Ember.Object;
+
+export default Helper.extend({
+
+});


### PR DESCRIPTION
A bit of a cheap check and could possibly be refactored more to join the alias checks but initial implementation of a check to see if we need to prepend `Ember` to the import name in case the name is already being used and not for alias purposes.